### PR TITLE
Add gnome-common to build-packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,7 @@ parts:
 
     build-packages:
       - gtk-update-icon-cache
+      - gnome-common
 
   # GNOME's default icon theme, also used by Fedora
   adwaita-icon-theme:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -85,6 +85,7 @@ parts:
       - librsvg2-dev
       - libgdk-pixbuf2.0-dev
       - libglib2.0-dev
+      - gnome-common
 
   # Ubuntu's default GTK and icon themes
   ubuntu-themes:


### PR DESCRIPTION
Added gnome-common to build-packages for gnome-themes-extra and hicolor-icon-theme