### PR TITLE
Renamed gtk3-themes slot to gtk-3-themes

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ grade: stable
 confinement: strict
 
 slots:
-  gtk3-themes:
+  gtk-3-themes:
     interface: content
     source:
       read:


### PR DESCRIPTION
Renamed gtk3-themes slot to gtk-3-themes per discussion https://forum.snapcraft.io/t/auto-connection-of-gtk3-themes-icon-themes-and-sound-themes-interfaces/5118/20