### PR TITLE
Use a branch tag instead of a tarball for sassc.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -235,7 +235,8 @@ parts:
     meson-parameters: [ --prefix=/ ]
   sassc:
     after: [ libsass ]
-    source: https://github.com/sass/sassc/archive/3.5.0.tar.gz
+    source: https://github.com/sass/sassc.git
+    source-tag: 3.5.0
     plugin: autotools
     override-prime: ""
   libsass:


### PR DESCRIPTION
This should work around an issue with launchpad builders where the build for sassc runs "git describe", thus updating the contents of the .git directory.